### PR TITLE
Fixed broken control flow in ChannelMessageProcessor.

### DIFF
--- a/src/main/java/com/github/otbproject/otbproject/messages/internal/InternalMessageSender.java
+++ b/src/main/java/com/github/otbproject/otbproject/messages/internal/InternalMessageSender.java
@@ -8,31 +8,15 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 public class InternalMessageSender {
-    private static final ExecutorService EXECUTOR_SERVICE;
     public static final String DESTINATION_PREFIX = "internal:";
     public static final String CLI = "cli";
 
-    static {
-        EXECUTOR_SERVICE = Executors.newCachedThreadPool(
-                new ThreadFactoryBuilder()
-                        .setNameFormat("Internal-Message-Sender-%d")
-                        .setUncaughtExceptionHandler((t, e) -> {
-                            App.logger.error("Thread crashed: " + t.getName());
-                            App.logger.catching(e);
-                        })
-                        .build()
-        );
-    }
-
     public static void send(String destination, String message, String source) {
-        // Ensure method call returns quickly
-        EXECUTOR_SERVICE.execute(() -> {
-            switch (destination) {
-                case CLI:
-                    sendToCli(message, source);
-                    break;
-            }
-        });
+        switch (destination) {
+            case CLI:
+                sendToCli(message, source);
+                break;
+        }
     }
 
     private static void sendToCli(String message, String source) {

--- a/src/main/java/com/github/otbproject/otbproject/messages/receive/ChannelMessageProcessor.java
+++ b/src/main/java/com/github/otbproject/otbproject/messages/receive/ChannelMessageProcessor.java
@@ -106,16 +106,14 @@ public class ChannelMessageProcessor {
         }
         // Send message
         else {
+            if (internal) {
+                InternalMessageSender.send(destChannelName.replace(InternalMessageSender.DESTINATION_PREFIX, ""), message, "CmdExec");
+                return;
+            }
             lock.lock();
             try {
-                if (internal) {
-                    InternalMessageSender.send(destChannelName.replace(InternalMessageSender.DESTINATION_PREFIX, ""), message, "CmdExec");
-                    return;
-                }
-                else {
-                    success = destChannel.sendMessage(new MessageOut(message, priority));
-                    doIncrement = postResponse(destChannelName, destChannel, command, user, ul, false, success);
-                }
+                success = destChannel.sendMessage(new MessageOut(message, priority));
+                doIncrement = postResponse(destChannelName, destChannel, command, user, ul, false, success);
             } finally {
                 lock.unlock();
             }

--- a/src/main/java/com/github/otbproject/otbproject/messages/receive/ChannelMessageProcessor.java
+++ b/src/main/java/com/github/otbproject/otbproject/messages/receive/ChannelMessageProcessor.java
@@ -85,7 +85,7 @@ public class ChannelMessageProcessor {
         }
     }
 
-    private void doResponse(DatabaseWrapper db, ProcessedMessage processedMsg, String channelName, String destChannelName, Channel destChanel, String user, UserLevel ul, MessagePriority priority, boolean internal) {
+    private void doResponse(DatabaseWrapper db, ProcessedMessage processedMsg, String channelName, String destChannelName, Channel destChannel, String user, UserLevel ul, MessagePriority priority, boolean internal) {
         String message = processedMsg.response;
         String command = processedMsg.commandName;
 
@@ -93,48 +93,61 @@ public class ChannelMessageProcessor {
         // There is a slight chance that a cooldown will have been set for the script command since the method was called,
         //  and that it will be run even though it's not supposed to, but processing a script takes too long to lock
         boolean success;
-        try {
-            if (processedMsg.isScript) {
-                success = CommandScriptProcessor.process(message, db, command, processedMsg.args, channelName, destChannelName, user, ul);
-                lock.lock();
+        boolean doIncrement;
+
+        if (processedMsg.isScript) {
+            success = CommandScriptProcessor.process(message, db, command, processedMsg.args, channelName, destChannelName, user, ul);
+            lock.lock();
+            try {
+                doIncrement = postResponse(destChannelName, destChannel, command, user, ul, internal, success);
+            } finally {
+                lock.unlock();
             }
-            // Send message
-            else {
-                lock.lock();
+        }
+        // Send message
+        else {
+            lock.lock();
+            try {
                 if (internal) {
                     InternalMessageSender.send(destChannelName.replace(InternalMessageSender.DESTINATION_PREFIX, ""), message, "CmdExec");
                     return;
                 }
-                // If queue rejects message because it's too full, return
                 else {
-                    MessageOut messageOut = new MessageOut(message, priority);
-                    success = destChanel.sendMessage(messageOut);
+                    success = destChannel.sendMessage(new MessageOut(message, priority));
+                    doIncrement = postResponse(destChannelName, destChannel, command, user, ul, false, success);
                 }
+            } finally {
+                lock.unlock();
             }
-            if (!success) {
-                return;
-            }
-
-            // Skip cooldowns if in or sending to bot channel, or internal
-            if (inBotChannel || destChannelName.equals(Bot.getBot().getUserName()) || internal) {
-                return;
-            }
-
-            // Handles command cooldowns
-            int commandCooldown = channel.getConfig().getCommandCooldown();
-            if (commandCooldown > 0) {
-                destChanel.addCommandCooldown(command, commandCooldown);
-            }
-            // Handles user cooldowns
-            int userCooldown = ChannelConfigHelper.getCooldown(channel.getConfig(), ul);
-            if (userCooldown > 0) {
-                destChanel.addUserCooldown(user, userCooldown);
-            }
-        } finally {
-            lock.unlock();
         }
 
         // Increment count (not essential to lock)
-        Commands.incrementCount(db, command);
+        if (doIncrement) {
+            Commands.incrementCount(db, command);
+        }
+    }
+
+    private boolean postResponse(String destChannelName, Channel destChannel, String command, String user, UserLevel ul, boolean internal, boolean success) {
+        if (!success) {
+            return false;
+        }
+
+        // Skip cooldowns if in or sending to bot channel, or internal
+        if (inBotChannel || destChannelName.equals(Bot.getBot().getUserName()) || internal) {
+            return false;
+        }
+
+        // Handles command cooldowns
+        int commandCooldown = channel.getConfig().getCommandCooldown();
+        if (commandCooldown > 0) {
+            destChannel.addCommandCooldown(command, commandCooldown);
+        }
+        // Handles user cooldowns
+        int userCooldown = ChannelConfigHelper.getCooldown(channel.getConfig(), ul);
+        if (userCooldown > 0) {
+            destChannel.addUserCooldown(user, userCooldown);
+        }
+
+        return true;
     }
 }


### PR DESCRIPTION
This fixes a somewhat major issue where, since `lock.lock()` was not called at the beginning of the try block, if the thread crashed inside the try block before `lock.lock()` was called, it would still attempt to call `lock.unlock()`, which would produce an `IllegalMonitorStateException` and obscure whatever actual `Exception` or `Error` had crashed the thread.