### PR TITLE
Save config when updating white/blacklist.

### DIFF
--- a/src/main/java/com/github/otbproject/otbproject/cli/commands/CmdParser.java
+++ b/src/main/java/com/github/otbproject/otbproject/cli/commands/CmdParser.java
@@ -209,8 +209,10 @@ public class CmdParser {
                             BotConfig config = Configs.getBotConfig();
                             if (config.getChannelJoinSetting() == ChannelJoinSetting.WHITELIST) {
                                 config.getWhitelist().add(channel);
+                                Configs.writeBotConfig();
                             } else if (config.getChannelJoinSetting() == ChannelJoinSetting.BLACKLIST) {
                                 config.getBlacklist().remove(channel);
+                                Configs.writeBotConfig();
                             }
                         }
                         String string = success ? "Successfully joined" : "Failed to join";


### PR DESCRIPTION
Forgot to write out the BotConfig after updating the whitelist or
blacklist when joining a channel from the CLI.