### PR TITLE
Fix NPE with GuiApplication

### DIFF
--- a/src/main/java/com/github/otbproject/otbproject/gui/GuiUtils.java
+++ b/src/main/java/com/github/otbproject/otbproject/gui/GuiUtils.java
@@ -6,6 +6,7 @@ import javafx.scene.control.Alert;
 import javafx.scene.control.Button;
 import javafx.scene.control.ButtonType;
 import javafx.scene.control.DialogPane;
+import org.apache.logging.log4j.Level;
 
 import java.net.URL;
 import java.util.Objects;
@@ -13,6 +14,21 @@ import java.util.Objects;
 public class GuiUtils {
     public static void runSafe(final Runnable runnable) {
         Objects.requireNonNull(runnable, "runnable");
+
+        // Attempt to prevent NPE by queueing Runnables if GuiApplication
+        // not ready
+        if (!GuiApplication.isReady()) {
+            GuiApplication.READY_LOCK.lock();
+            try {
+                if (!GuiApplication.isReady()) {
+                    GuiApplication.NOT_READY_QUEUE.add(runnable);
+                    return;
+                }
+            } finally {
+                GuiApplication.READY_LOCK.unlock();
+            }
+        }
+
         if (Platform.isFxApplicationThread()) {
             runnable.run();
         } else {


### PR DESCRIPTION
Prevent Runnables from being run in the JavaFX Application Thread
before GuiApplication is fully initialized, thus hopefully
preventing some NPEs.