### PR TITLE
Rewrite channel APIs

### DIFF
--- a/src/main/java/com/github/otbproject/otbproject/bot/AbstractBot.java
+++ b/src/main/java/com/github/otbproject/otbproject/bot/AbstractBot.java
@@ -45,6 +45,10 @@ public abstract class AbstractBot implements Bot {
         return botDB;
     }
 
+    /**
+     * Any class extending this one which overrides this method SHOULD call
+     * this method at the end of the body of the overriding method
+     */
     @Override
     public void shutdown() {
         channels.values().forEach(proxiedChannel -> proxiedChannel.channel().leave());

--- a/src/main/java/com/github/otbproject/otbproject/bot/AbstractBot.java
+++ b/src/main/java/com/github/otbproject/otbproject/bot/AbstractBot.java
@@ -3,6 +3,7 @@ package com.github.otbproject.otbproject.bot;
 import com.github.otbproject.otbproject.App;
 import com.github.otbproject.otbproject.channel.Channel;
 import com.github.otbproject.otbproject.channel.ChannelManager;
+import com.github.otbproject.otbproject.channel.ChannelProxy;
 import com.github.otbproject.otbproject.channel.ProxiedChannel;
 import com.github.otbproject.otbproject.database.DatabaseWrapper;
 import com.github.otbproject.otbproject.database.Databases;
@@ -68,7 +69,7 @@ public abstract class AbstractBot implements Bot {
     }
 
     @Override
-    public void invokeMessageHandlers(Channel channel, PackagedMessage message, boolean timedOut) {
+    public void invokeMessageHandlers(ChannelProxy channel, PackagedMessage message, boolean timedOut) {
         messageHandlers.onMessage(channel, message, timedOut);
     }
 }

--- a/src/main/java/com/github/otbproject/otbproject/bot/Bot.java
+++ b/src/main/java/com/github/otbproject/otbproject/bot/Bot.java
@@ -1,6 +1,7 @@
 package com.github.otbproject.otbproject.bot;
 
 import com.github.otbproject.otbproject.channel.Channel;
+import com.github.otbproject.otbproject.channel.ChannelManager;
 import com.github.otbproject.otbproject.database.DatabaseWrapper;
 import com.github.otbproject.otbproject.messages.receive.PackagedMessage;
 import com.github.otbproject.otbproject.messages.receive.MessageHandler;
@@ -12,7 +13,10 @@ public interface Bot {
 
     boolean isConnected();
 
-    ConcurrentMap<String, Channel> getChannels();
+    @Deprecated
+    ConcurrentMap<String, Channel> getChannels(); // TODO remove
+
+    ChannelManager channelManager();
 
     boolean isChannel(String channelName);
 

--- a/src/main/java/com/github/otbproject/otbproject/bot/Bot.java
+++ b/src/main/java/com/github/otbproject/otbproject/bot/Bot.java
@@ -2,6 +2,7 @@ package com.github.otbproject.otbproject.bot;
 
 import com.github.otbproject.otbproject.channel.Channel;
 import com.github.otbproject.otbproject.channel.ChannelManager;
+import com.github.otbproject.otbproject.channel.ChannelProxy;
 import com.github.otbproject.otbproject.database.DatabaseWrapper;
 import com.github.otbproject.otbproject.messages.receive.PackagedMessage;
 import com.github.otbproject.otbproject.messages.receive.MessageHandler;
@@ -14,7 +15,7 @@ public interface Bot {
     boolean isConnected();
 
     @Deprecated
-    ConcurrentMap<String, Channel> getChannels(); // TODO remove
+    ConcurrentMap<String, Channel> getChannels();
 
     ChannelManager channelManager();
 
@@ -48,5 +49,5 @@ public interface Bot {
 
     void onMessage(MessageHandler messageHandler);
 
-    void invokeMessageHandlers(Channel channel, PackagedMessage message, boolean timedOut);
+    void invokeMessageHandlers(ChannelProxy channel, PackagedMessage message, boolean timedOut);
 }

--- a/src/main/java/com/github/otbproject/otbproject/bot/BotUtil.java
+++ b/src/main/java/com/github/otbproject/otbproject/bot/BotUtil.java
@@ -1,8 +1,7 @@
 package com.github.otbproject.otbproject.bot;
 
-import com.github.otbproject.otbproject.channel.Channel;
 import com.github.otbproject.otbproject.channel.ChannelNotFoundException;
-import com.github.otbproject.otbproject.channel.Channels;
+import com.github.otbproject.otbproject.channel.ChannelProxy;
 import com.github.otbproject.otbproject.database.DatabaseWrapper;
 import com.github.otbproject.otbproject.user.UserLevel;
 import com.github.otbproject.otbproject.user.UserLevels;
@@ -10,7 +9,7 @@ import com.github.otbproject.otbproject.user.UserLevels;
 public class BotUtil {
     public static boolean isModOrHigher(String channelName, String user) throws ChannelNotFoundException {
         // Check if user has user level mod or higher
-        Channel channel = Channels.getOrThrow(channelName);
+        ChannelProxy channel = Control.getBot().channelManager().getOrThrow(channelName);
         DatabaseWrapper db = channel.getMainDatabaseWrapper();
         UserLevel ul = UserLevels.getUserLevel(db, channelName, user);
         return ul.getValue() >= UserLevel.MODERATOR.getValue();

--- a/src/main/java/com/github/otbproject/otbproject/bot/Control.java
+++ b/src/main/java/com/github/otbproject/otbproject/bot/Control.java
@@ -91,7 +91,6 @@ public class Control {
 
     private static void shutdownCleanup(Bot bot) {
         clearCaches();
-        bot.getChannels().clear();
         // TODO unload libs?
     }
 

--- a/src/main/java/com/github/otbproject/otbproject/bot/beam/BeamBot.java
+++ b/src/main/java/com/github/otbproject/otbproject/bot/beam/BeamBot.java
@@ -6,7 +6,6 @@ import com.github.otbproject.otbproject.bot.BotInitException;
 import com.github.otbproject.otbproject.bot.BotUtil;
 import com.github.otbproject.otbproject.channel.ChannelInitException;
 import com.github.otbproject.otbproject.channel.ChannelNotFoundException;
-import com.github.otbproject.otbproject.channel.Channels;
 import com.github.otbproject.otbproject.channel.JoinCheck;
 import com.github.otbproject.otbproject.config.Account;
 import com.github.otbproject.otbproject.config.BotConfig;
@@ -115,8 +114,8 @@ public class BeamBot extends AbstractBot {
 
     @Override
     public void startBot() {
-        Channels.join(getUserName(), EnumSet.of(JoinCheck.WHITELIST, JoinCheck.BLACKLIST));
-        Configs.getFromBotConfig(BotConfig::getCurrentChannels).forEach(channel -> Channels.join(channel, EnumSet.of(JoinCheck.WHITELIST, JoinCheck.BLACKLIST)));
+        channelManager().join(getUserName(), EnumSet.of(JoinCheck.WHITELIST, JoinCheck.BLACKLIST));
+        Configs.getFromBotConfig(BotConfig::getCurrentChannels).forEach(channel -> channelManager().join(channel, EnumSet.of(JoinCheck.WHITELIST, JoinCheck.BLACKLIST)));
         while (!beamChannels.isEmpty()) {
             try {
                 Thread.sleep(200);

--- a/src/main/java/com/github/otbproject/otbproject/bot/beam/BeamMessageHandler.java
+++ b/src/main/java/com/github/otbproject/otbproject/bot/beam/BeamMessageHandler.java
@@ -3,9 +3,7 @@ package com.github.otbproject.otbproject.bot.beam;
 import com.github.otbproject.otbproject.App;
 import com.github.otbproject.otbproject.bot.BotUtil;
 import com.github.otbproject.otbproject.bot.Control;
-import com.github.otbproject.otbproject.channel.Channel;
-import com.github.otbproject.otbproject.channel.ChannelNotFoundException;
-import com.github.otbproject.otbproject.channel.Channels;
+import com.github.otbproject.otbproject.channel.*;
 import com.github.otbproject.otbproject.messages.receive.PackagedMessage;
 import com.github.otbproject.otbproject.messages.send.MessagePriority;
 import com.github.otbproject.otbproject.proc.TimeoutProcessor;
@@ -79,9 +77,9 @@ public class BeamMessageHandler implements EventHandler<IncomingMessageEvent> {
                 return;
             }
 
-            Optional<Channel> optional = Channels.get(channelName);
+            Optional<ChannelProxy> optional = bot.channelManager().get(channelName);
             if (optional.isPresent()) {
-                Channel channel = optional.get();
+                ChannelProxy channel = optional.get();
                 UserLevel userLevel = UserLevels.getUserLevel(channel.getMainDatabaseWrapper(), channelName, data.user_name.toLowerCase());
                 PackagedMessage packagedMessage = new PackagedMessage(message, data.user_name.toLowerCase(), channelName, userLevel, MessagePriority.DEFAULT);
                 bot.invokeMessageHandlers(channel, packagedMessage, TimeoutProcessor.doTimeouts(channel, packagedMessage));

--- a/src/main/java/com/github/otbproject/otbproject/bot/irc/IrcListener.java
+++ b/src/main/java/com/github/otbproject/otbproject/bot/irc/IrcListener.java
@@ -2,8 +2,8 @@ package com.github.otbproject.otbproject.bot.irc;
 
 import com.github.otbproject.otbproject.App;
 import com.github.otbproject.otbproject.bot.Control;
-import com.github.otbproject.otbproject.channel.Channel;
-import com.github.otbproject.otbproject.channel.Channels;
+import com.github.otbproject.otbproject.channel.ChannelManager;
+import com.github.otbproject.otbproject.channel.ChannelProxy;
 import com.github.otbproject.otbproject.channel.JoinCheck;
 import com.github.otbproject.otbproject.config.BotConfig;
 import com.github.otbproject.otbproject.config.Configs;
@@ -23,12 +23,12 @@ class IrcListener extends ListenerAdapter {
     @Override
     public void onMessage(MessageEvent event) throws Exception {
         String channelName = IRCHelper.getInternalChannelName(event.getChannel().getName());
-        Optional<Channel> optional = Channels.get(channelName);
+        Optional<ChannelProxy> optional = Control.getBot().channelManager().get(channelName);
         if (!optional.isPresent()) {
             App.logger.error("The channel '" + channelName + "' really shouldn't be null here. Something has gone terribly wrong.");
             return;
         }
-        Channel channel = optional.get();
+        ChannelProxy channel = optional.get();
 
         String user = event.getUser().getNick().toLowerCase();
 
@@ -63,10 +63,11 @@ class IrcListener extends ListenerAdapter {
 
     @Override
     public void onConnect(ConnectEvent event) {
+        ChannelManager channelManager = Control.getBot().channelManager();
         // Join bot channel
-        Channels.join(Control.getBot().getUserName(), EnumSet.of(JoinCheck.WHITELIST, JoinCheck.BLACKLIST));
+        channelManager.join(Control.getBot().getUserName(), EnumSet.of(JoinCheck.WHITELIST, JoinCheck.BLACKLIST));
         // Join channels
-        Configs.getFromBotConfig(BotConfig::getCurrentChannels).forEach(channel -> Channels.join(channel, EnumSet.of(JoinCheck.WHITELIST, JoinCheck.BLACKLIST)));
+        Configs.getFromBotConfig(BotConfig::getCurrentChannels).forEach(channel -> channelManager.join(channel, EnumSet.of(JoinCheck.WHITELIST, JoinCheck.BLACKLIST)));
     }
 
 }

--- a/src/main/java/com/github/otbproject/otbproject/bot/nullbot/NullBot.java
+++ b/src/main/java/com/github/otbproject/otbproject/bot/nullbot/NullBot.java
@@ -3,6 +3,8 @@ package com.github.otbproject.otbproject.bot.nullbot;
 import com.github.otbproject.otbproject.bot.Bot;
 import com.github.otbproject.otbproject.bot.BotInitException;
 import com.github.otbproject.otbproject.channel.Channel;
+import com.github.otbproject.otbproject.channel.ChannelManager;
+import com.github.otbproject.otbproject.channel.ProxiedChannel;
 import com.github.otbproject.otbproject.database.DatabaseWrapper;
 import com.github.otbproject.otbproject.messages.receive.MessageHandler;
 import com.github.otbproject.otbproject.messages.receive.PackagedMessage;
@@ -10,9 +12,13 @@ import com.github.otbproject.otbproject.messages.receive.PackagedMessage;
 import java.util.concurrent.ConcurrentMap;
 
 public class NullBot implements Bot {
-    private static final ConcurrentMap<String, Channel> CHANNELS = new EmptyConcurrentMap<>();
+    private static final ConcurrentMap<String, ProxiedChannel> CHANNELS = new EmptyConcurrentMap<>();
+    private static final ChannelManager channelManager = new ChannelManager(CHANNELS);
     private static final DatabaseWrapper DATABASE_WRAPPER = new EmptyDatabaseWrapper();
     public static final NullBot INSTANCE = new NullBot();
+
+    @Deprecated // TODO REMOVE
+    private static final ConcurrentMap<String, Channel> DEPRECATED_CHANNELS = new EmptyConcurrentMap<>();
 
     private NullBot() {
     }
@@ -29,7 +35,12 @@ public class NullBot implements Bot {
 
     @Override
     public ConcurrentMap<String, Channel> getChannels() {
-        return CHANNELS;
+        return DEPRECATED_CHANNELS;
+    }
+
+    @Override
+    public ChannelManager channelManager() {
+        return channelManager;
     }
 
     @Override

--- a/src/main/java/com/github/otbproject/otbproject/bot/nullbot/NullBot.java
+++ b/src/main/java/com/github/otbproject/otbproject/bot/nullbot/NullBot.java
@@ -4,6 +4,7 @@ import com.github.otbproject.otbproject.bot.Bot;
 import com.github.otbproject.otbproject.bot.BotInitException;
 import com.github.otbproject.otbproject.channel.Channel;
 import com.github.otbproject.otbproject.channel.ChannelManager;
+import com.github.otbproject.otbproject.channel.ChannelProxy;
 import com.github.otbproject.otbproject.channel.ProxiedChannel;
 import com.github.otbproject.otbproject.database.DatabaseWrapper;
 import com.github.otbproject.otbproject.messages.receive.MessageHandler;
@@ -119,7 +120,7 @@ public class NullBot implements Bot {
     }
 
     @Override
-    public void invokeMessageHandlers(Channel channel, PackagedMessage message, boolean timedOut) {
+    public void invokeMessageHandlers(ChannelProxy channel, PackagedMessage message, boolean timedOut) {
         // NO-OP
     }
 }

--- a/src/main/java/com/github/otbproject/otbproject/channel/Channel.java
+++ b/src/main/java/com/github/otbproject/otbproject/channel/Channel.java
@@ -25,7 +25,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
-public class Channel {
+public class Channel implements ChannelProxy {
     private CooldownManager commandCooldownManager;
     private CooldownManager userCooldownManager;
     private final String name;
@@ -296,7 +296,7 @@ public class Channel {
         return channel.equalsIgnoreCase(Control.getBot().getUserName());
     }
 
-    public static boolean isBotChannel(Channel channel) {
+    public static boolean isBotChannel(ChannelProxy channel) {
         return isBotChannel(channel.getName());
     }
 }

--- a/src/main/java/com/github/otbproject/otbproject/channel/Channel.java
+++ b/src/main/java/com/github/otbproject/otbproject/channel/Channel.java
@@ -15,6 +15,7 @@ import com.github.otbproject.otbproject.messages.receive.PackagedMessage;
 import com.github.otbproject.otbproject.messages.send.ChannelMessageSender;
 import com.github.otbproject.otbproject.messages.send.MessageOut;
 
+import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -202,7 +203,7 @@ public class Channel {
     }
 
     public Set<String> getScheduledCommands() {
-        return scheduledCommands.keySet();
+        return Collections.unmodifiableSet(scheduledCommands.keySet());
     }
 
     public ChannelScheduleManager getScheduleManager() {

--- a/src/main/java/com/github/otbproject/otbproject/channel/ChannelManager.java
+++ b/src/main/java/com/github/otbproject/otbproject/channel/ChannelManager.java
@@ -29,7 +29,8 @@ public final class ChannelManager {
     }
 
     public Optional<ChannelProxy> get(String channel) {
-        return Optional.ofNullable(channels.get(channel).proxy());
+        ProxiedChannel proxiedChannel = channels.get(channel);
+        return (proxiedChannel == null) ? Optional.empty() : Optional.of(channels.get(channel).proxy());
     }
 
     public ChannelProxy getOrThrow(String channel) throws ChannelNotFoundException {

--- a/src/main/java/com/github/otbproject/otbproject/channel/ChannelManager.java
+++ b/src/main/java/com/github/otbproject/otbproject/channel/ChannelManager.java
@@ -13,6 +13,7 @@ import java.util.*;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.stream.Stream;
 
 public final class ChannelManager {
     private final Lock lock = new ReentrantLock();
@@ -159,4 +160,7 @@ public final class ChannelManager {
         return Collections.unmodifiableSet(channels.keySet());
     }
 
+    public Stream<ChannelProxy> proxyStream() {
+        return channels.values().stream().map(ProxiedChannel::proxy);
+    }
 }

--- a/src/main/java/com/github/otbproject/otbproject/channel/ChannelManager.java
+++ b/src/main/java/com/github/otbproject/otbproject/channel/ChannelManager.java
@@ -1,0 +1,162 @@
+package com.github.otbproject.otbproject.channel;
+
+import com.github.otbproject.otbproject.App;
+import com.github.otbproject.otbproject.bot.Bot;
+import com.github.otbproject.otbproject.bot.Control;
+import com.github.otbproject.otbproject.config.*;
+import com.github.otbproject.otbproject.fs.FSUtil;
+import com.github.otbproject.otbproject.fs.Setup;
+import com.github.otbproject.otbproject.util.StrUtils;
+
+import java.io.IOException;
+import java.util.*;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+public final class ChannelManager {
+    private final Lock lock = new ReentrantLock();
+    private final ConcurrentMap<String, ProxiedChannel> channels;
+
+    public ChannelManager(ConcurrentMap<String, ProxiedChannel> channels) {
+        this.channels = channels;
+    }
+
+    public boolean in(String channelName) {
+        Optional<ChannelProxy> optional = get(channelName);
+        return optional.isPresent() && optional.get().isInChannel();
+    }
+
+    public Optional<ChannelProxy> get(String channel) {
+        return Optional.ofNullable(channels.get(channel).proxy());
+    }
+
+    public ChannelProxy getOrThrow(String channel) throws ChannelNotFoundException {
+        return get(channel).orElseThrow(ChannelNotFoundException::new);
+    }
+
+    public boolean join(String channelName) {
+        return join(channelName, JoinCheck.ALL_CHECKS);
+    }
+
+    public boolean join(String channelName, EnumSet<JoinCheck> checks) {
+        return doJoin(channelName.toLowerCase(), checks);
+    }
+
+    private boolean doJoin(final String channelName, EnumSet<JoinCheck> checks) {
+        App.logger.info("Attempting to join channel: " + channelName);
+
+        lock.lock();
+        try {
+            if (in(channelName)) {
+                App.logger.info("Failed to join channel: " + channelName + ". Already in channel");
+                return false;
+            }
+
+            boolean isBotChannel = Channel.isBotChannel(channelName);
+            Bot bot = Control.getBot();
+
+            // Check if bot is connected
+            if (!bot.isConnected()) {
+                App.logger.warn("Not connected to " + StrUtils.capitalizeFully(Configs.getFromGeneralConfig(GeneralConfig::getService).toString()));
+                return false;
+            }
+
+            // Check whitelist/blacklist
+            ChannelJoinSetting channelJoinSetting = Configs.getFromBotConfig(BotConfig::getChannelJoinSetting);
+            if (!isBotChannel) {
+                if (checks.contains(JoinCheck.WHITELIST)
+                        && (channelJoinSetting == ChannelJoinSetting.WHITELIST)
+                        && !Configs.getFromBotConfig(BotConfig::getWhitelist).contains(channelName)) {
+                    App.logger.info("Failed to join channel: " + channelName + ". Not whitelisted.");
+                    return false;
+                } else if (checks.contains(JoinCheck.BLACKLIST)
+                        && (channelJoinSetting == ChannelJoinSetting.BLACKLIST)
+                        && Configs.getFromBotConfig(BotConfig::getBlacklist).contains(channelName)) {
+                    App.logger.info("Failed to join channel: " + channelName + ". Blacklisted.");
+                    return false;
+                }
+            }
+
+            if (checks.contains(JoinCheck.IS_CHANNEL) && !bot.isChannel(channelName)) {
+                App.logger.info("Failed to join channel: " + channelName + ". Channel does not exist.");
+                return false;
+
+            }
+
+            // Setup channel files
+            try {
+                Setup.setupChannel(channelName);
+            } catch (IOException e) {
+                App.logger.error("Failed to setup channel: " + channelName);
+                App.logger.catching(e);
+                return false;
+            }
+
+            // Connect to channel
+            if (!bot.isConnected(channelName)) {
+                if (!bot.join(channelName)) {
+                    App.logger.warn("Failed to connect to channel: " + channelName);
+                    return false;
+                }
+            } else {
+                App.logger.error("Already connected to channel: " + channelName);
+            }
+
+            // Create and join channel object
+            ProxiedChannel proxiedChannel = channels.get(channelName);
+            Channel channel;
+            if (proxiedChannel == null) {
+                try {
+                    UpdatingConfig<ChannelConfig> updatingConfig = UpdatingConfig.create(ChannelConfig.class,
+                            FSUtil.channelDataDir(channelName), FSUtil.ConfigFileNames.CHANNEL_CONFIG, ChannelConfig::new);
+                    channel = Channel.create(channelName, updatingConfig);
+                } catch (ChannelInitException e) {
+                    App.logger.catching(e);
+                    // Disconnect from channel if failed to create channel object
+                    bot.leave(channelName);
+                    return false;
+                }
+                channels.put(channelName, new ProxiedChannel(channel));
+            } else {
+                channel = proxiedChannel.channel();
+            }
+            channel.join();
+
+            // Add channel to list of channels bot is in in config (if not bot channel)
+            if (!isBotChannel) {
+                Configs.editBotConfig(config -> config.getCurrentChannels().add(channelName));
+            }
+        } finally {
+            lock.unlock();
+        }
+        App.logger.info("Successfully joined channel: " + channelName);
+        return true;
+    }
+
+    public boolean leave(String channelName) {
+        final String channel = channelName.toLowerCase();
+        lock.lock();
+        try {
+            if (!in(channel)) {
+                App.logger.info("Not leaving channel '" + channel + "' - not in channel");
+                return false;
+            } else if (channel.equals(Control.getBot().getUserName())) {
+                App.logger.info("Not leaving channel '" + channel + "' - cannot leave bot channel");
+                return false;
+            }
+            App.logger.info("Leaving channel: " + channel);
+            Optional.ofNullable(channels.remove(channel)).ifPresent(proxiedChannel -> proxiedChannel.channel().leave());
+            Configs.editBotConfig(config -> config.getCurrentChannels().remove(channel));
+            Control.getBot().leave(channel);
+        } finally {
+            lock.unlock();
+        }
+        return true;
+    }
+
+    public Set<String> list() {
+        return Collections.unmodifiableSet(channels.keySet());
+    }
+
+}

--- a/src/main/java/com/github/otbproject/otbproject/channel/ChannelManager.java
+++ b/src/main/java/com/github/otbproject/otbproject/channel/ChannelManager.java
@@ -30,7 +30,7 @@ public final class ChannelManager {
 
     public Optional<ChannelProxy> get(String channel) {
         ProxiedChannel proxiedChannel = channels.get(channel);
-        return (proxiedChannel == null) ? Optional.empty() : Optional.of(channels.get(channel).proxy());
+        return (proxiedChannel == null) ? Optional.empty() : Optional.of(proxiedChannel.proxy());
     }
 
     public ChannelProxy getOrThrow(String channel) throws ChannelNotFoundException {

--- a/src/main/java/com/github/otbproject/otbproject/channel/ChannelProxy.java
+++ b/src/main/java/com/github/otbproject/otbproject/channel/ChannelProxy.java
@@ -14,71 +14,34 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
-public class ChannelProxy {
-    private final Channel channel;
+public interface ChannelProxy {
+    boolean sendMessage(MessageOut messageOut);
 
-    public ChannelProxy(Channel channel) {
-        this.channel = channel;
-    }
+    void clearSendQueue();
 
-    public boolean sendMessage(MessageOut messageOut) {
-        return channel.sendMessage(messageOut);
-    }
+    boolean receiveMessage(PackagedMessage packagedMessage);
 
-    public void clearSendQueue() {
-        channel.clearSendQueue();
-    }
+    String getName();
 
-    public boolean receiveMessage(PackagedMessage packagedMessage) {
-        return channel.receiveMessage(packagedMessage);
-    }
+    boolean isInChannel();
 
-    public String getName() {
-        return channel.getName();
-    }
+    CooldownManager userCooldowns();
 
-    public boolean isInChannel() {
-        return channel.isInChannel();
-    }
+    CooldownManager commandCooldowns();
 
-    public CooldownManager userCooldowns() {
-        return channel.userCooldowns();
-    }
+    Set<String> getScheduledCommands();
 
-    public CooldownManager commandCooldowns() {
-        return channel.commandCooldowns();
-    }
+    ChannelScheduleManager getScheduleManager();
 
-    public Set<String> getScheduledCommands() {
-        return channel.getScheduledCommands();
-    }
+    DatabaseWrapper getMainDatabaseWrapper();
 
-    public ChannelScheduleManager getScheduleManager() {
-        return channel.getScheduleManager();
-    }
+    SQLiteQuoteWrapper getQuoteDatabaseWrapper();
 
-    public DatabaseWrapper getMainDatabaseWrapper() {
-        return channel.getMainDatabaseWrapper();
-    }
+    <R> R getFromConfig(Function<ChannelConfig, R> function);
 
-    public SQLiteQuoteWrapper getQuoteDatabaseWrapper() {
-        return channel.getQuoteDatabaseWrapper();
-    }
+    void editConfig(Consumer<ChannelConfig> consumer);
 
-    public <R> R getFromConfig(Function<ChannelConfig, R> function) {
-        return channel.getFromConfig(function);
-    }
+    Scheduler getScheduler();
 
-    public void editConfig(Consumer<ChannelConfig> consumer) {
-        channel.editConfig(consumer);
-    }
-
-    public Scheduler getScheduler() {
-        return channel.getScheduler();
-    }
-
-    public ConcurrentMap<String, GroupFilterSet> getFilterMap() {
-        return channel.getFilterMap();
-    }
-
+    ConcurrentMap<String, GroupFilterSet> getFilterMap();
 }

--- a/src/main/java/com/github/otbproject/otbproject/channel/ChannelProxy.java
+++ b/src/main/java/com/github/otbproject/otbproject/channel/ChannelProxy.java
@@ -1,0 +1,84 @@
+package com.github.otbproject.otbproject.channel;
+
+import com.github.otbproject.otbproject.command.scheduler.ChannelScheduleManager;
+import com.github.otbproject.otbproject.command.scheduler.Scheduler;
+import com.github.otbproject.otbproject.config.ChannelConfig;
+import com.github.otbproject.otbproject.database.DatabaseWrapper;
+import com.github.otbproject.otbproject.database.SQLiteQuoteWrapper;
+import com.github.otbproject.otbproject.filter.GroupFilterSet;
+import com.github.otbproject.otbproject.messages.receive.PackagedMessage;
+import com.github.otbproject.otbproject.messages.send.MessageOut;
+
+import java.util.Set;
+import java.util.concurrent.ConcurrentMap;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+public class ChannelProxy {
+    private final Channel channel;
+
+    public ChannelProxy(Channel channel) {
+        this.channel = channel;
+    }
+
+    public boolean sendMessage(MessageOut messageOut) {
+        return channel.sendMessage(messageOut);
+    }
+
+    public void clearSendQueue() {
+        channel.clearSendQueue();
+    }
+
+    public boolean receiveMessage(PackagedMessage packagedMessage) {
+        return channel.receiveMessage(packagedMessage);
+    }
+
+    public String getName() {
+        return channel.getName();
+    }
+
+    public boolean isInChannel() {
+        return channel.isInChannel();
+    }
+
+    public CooldownManager userCooldowns() {
+        return channel.userCooldowns();
+    }
+
+    public CooldownManager commandCooldowns() {
+        return channel.commandCooldowns();
+    }
+
+    public Set<String> getScheduledCommands() {
+        return channel.getScheduledCommands();
+    }
+
+    public ChannelScheduleManager getScheduleManager() {
+        return channel.getScheduleManager();
+    }
+
+    public DatabaseWrapper getMainDatabaseWrapper() {
+        return channel.getMainDatabaseWrapper();
+    }
+
+    public SQLiteQuoteWrapper getQuoteDatabaseWrapper() {
+        return channel.getQuoteDatabaseWrapper();
+    }
+
+    public <R> R getFromConfig(Function<ChannelConfig, R> function) {
+        return channel.getFromConfig(function);
+    }
+
+    public void editConfig(Consumer<ChannelConfig> consumer) {
+        channel.editConfig(consumer);
+    }
+
+    public Scheduler getScheduler() {
+        return channel.getScheduler();
+    }
+
+    public ConcurrentMap<String, GroupFilterSet> getFilterMap() {
+        return channel.getFilterMap();
+    }
+
+}

--- a/src/main/java/com/github/otbproject/otbproject/channel/ChannelProxyImpl.java
+++ b/src/main/java/com/github/otbproject/otbproject/channel/ChannelProxyImpl.java
@@ -1,0 +1,99 @@
+package com.github.otbproject.otbproject.channel;
+
+import com.github.otbproject.otbproject.command.scheduler.ChannelScheduleManager;
+import com.github.otbproject.otbproject.command.scheduler.Scheduler;
+import com.github.otbproject.otbproject.config.ChannelConfig;
+import com.github.otbproject.otbproject.database.DatabaseWrapper;
+import com.github.otbproject.otbproject.database.SQLiteQuoteWrapper;
+import com.github.otbproject.otbproject.filter.GroupFilterSet;
+import com.github.otbproject.otbproject.messages.receive.PackagedMessage;
+import com.github.otbproject.otbproject.messages.send.MessageOut;
+
+import java.util.Set;
+import java.util.concurrent.ConcurrentMap;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+class ChannelProxyImpl implements ChannelProxy {
+    private final Channel channel;
+
+    public ChannelProxyImpl(Channel channel) {
+        this.channel = channel;
+    }
+
+    @Override
+    public boolean sendMessage(MessageOut messageOut) {
+        return channel.sendMessage(messageOut);
+    }
+
+    @Override
+    public void clearSendQueue() {
+        channel.clearSendQueue();
+    }
+
+    @Override
+    public boolean receiveMessage(PackagedMessage packagedMessage) {
+        return channel.receiveMessage(packagedMessage);
+    }
+
+    @Override
+    public String getName() {
+        return channel.getName();
+    }
+
+    @Override
+    public boolean isInChannel() {
+        return channel.isInChannel();
+    }
+
+    @Override
+    public CooldownManager userCooldowns() {
+        return channel.userCooldowns();
+    }
+
+    @Override
+    public CooldownManager commandCooldowns() {
+        return channel.commandCooldowns();
+    }
+
+    @Override
+    public Set<String> getScheduledCommands() {
+        return channel.getScheduledCommands();
+    }
+
+    @Override
+    public ChannelScheduleManager getScheduleManager() {
+        return channel.getScheduleManager();
+    }
+
+    @Override
+    public DatabaseWrapper getMainDatabaseWrapper() {
+        return channel.getMainDatabaseWrapper();
+    }
+
+    @Override
+    public SQLiteQuoteWrapper getQuoteDatabaseWrapper() {
+        return channel.getQuoteDatabaseWrapper();
+    }
+
+    @Override
+    public <R> R getFromConfig(Function<ChannelConfig, R> function) {
+        return channel.getFromConfig(function);
+    }
+
+    @Override
+    public void editConfig(Consumer<ChannelConfig> consumer) {
+        channel.editConfig(consumer);
+    }
+
+    @Override
+    public Scheduler getScheduler() {
+        return channel.getScheduler();
+    }
+
+    @Override
+    public ConcurrentMap<String, GroupFilterSet> getFilterMap() {
+        return channel.getFilterMap();
+    }
+
+}

--- a/src/main/java/com/github/otbproject/otbproject/channel/Channels.java
+++ b/src/main/java/com/github/otbproject/otbproject/channel/Channels.java
@@ -1,26 +1,15 @@
 package com.github.otbproject.otbproject.channel;
 
-import com.github.otbproject.otbproject.App;
-import com.github.otbproject.otbproject.bot.Bot;
 import com.github.otbproject.otbproject.bot.Control;
-import com.github.otbproject.otbproject.config.*;
-import com.github.otbproject.otbproject.fs.FSUtil;
-import com.github.otbproject.otbproject.fs.Setup;
-import com.github.otbproject.otbproject.util.StrUtils;
 
-import java.io.IOException;
 import java.util.EnumSet;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
 
+@Deprecated
 public class Channels {
-    private static final Lock lock = new ReentrantLock();
-
     public static boolean in(String channelName) {
-        Optional<Channel> optional = get(channelName);
-        return optional.isPresent() && optional.get().isInChannel();
+        return Control.getBot().channelManager().in(channelName);
     }
 
     public static Optional<Channel> get(String channel) {
@@ -32,127 +21,19 @@ public class Channels {
     }
 
     public static boolean join(String channelName) {
-        return join(channelName, JoinCheck.ALL_CHECKS);
+        return Control.getBot().channelManager().join(channelName);
     }
 
     public static boolean join(String channelName, EnumSet<JoinCheck> checks) {
-        return doJoin(channelName.toLowerCase(), checks);
-    }
-
-    private static boolean doJoin(final String channelName, EnumSet<JoinCheck> checks) {
-        App.logger.info("Attempting to join channel: " + channelName);
-
-        lock.lock();
-        try {
-            if (in(channelName)) {
-                App.logger.info("Failed to join channel: " + channelName + ". Already in channel");
-                return false;
-            }
-
-            Bot bot = Control.getBot();
-            boolean isBotChannel = channelName.equals(bot.getUserName());
-
-            // Check if bot is connected
-            if (!bot.isConnected()) {
-                App.logger.warn("Not connected to " + StrUtils.capitalizeFully(Configs.getFromGeneralConfig(GeneralConfig::getService).toString()));
-                return false;
-            }
-
-            // Check whitelist/blacklist
-            ChannelJoinSetting channelJoinSetting = Configs.getFromBotConfig(BotConfig::getChannelJoinSetting);
-            if (!isBotChannel) {
-                if (checks.contains(JoinCheck.WHITELIST)
-                        && (channelJoinSetting == ChannelJoinSetting.WHITELIST)
-                        && !Configs.getFromBotConfig(BotConfig::getWhitelist).contains(channelName)) {
-                    App.logger.info("Failed to join channel: " + channelName + ". Not whitelisted.");
-                    return false;
-                } else if (checks.contains(JoinCheck.BLACKLIST)
-                        && (channelJoinSetting == ChannelJoinSetting.BLACKLIST)
-                        && Configs.getFromBotConfig(BotConfig::getBlacklist).contains(channelName)) {
-                    App.logger.info("Failed to join channel: " + channelName + ". Blacklisted.");
-                    return false;
-                }
-            }
-
-            if (checks.contains(JoinCheck.IS_CHANNEL) && !bot.isChannel(channelName)) {
-                App.logger.info("Failed to join channel: " + channelName + ". Channel does not exist.");
-                return false;
-
-            }
-
-            // Setup channel files
-            try {
-                Setup.setupChannel(channelName);
-            } catch (IOException e) {
-                App.logger.error("Failed to setup channel: " + channelName);
-                App.logger.catching(e);
-                return false;
-            }
-
-            // Connect to channel
-            if (!bot.isConnected(channelName)) {
-                if (!bot.join(channelName)) {
-                    App.logger.warn("Failed to connect to channel: " + channelName);
-                    return false;
-                }
-            } else {
-                App.logger.error("Already connected to channel: " + channelName);
-            }
-
-            // Create and join channel object
-            Optional<Channel> optional = get(channelName);
-            Channel channel;
-            if (!optional.isPresent()) {
-                try {
-                    UpdatingConfig<ChannelConfig> updatingConfig = UpdatingConfig.create(ChannelConfig.class,
-                            FSUtil.channelDataDir(channelName), FSUtil.ConfigFileNames.CHANNEL_CONFIG, ChannelConfig::new);
-                    channel = Channel.create(channelName, updatingConfig);
-                } catch (ChannelInitException e) {
-                    App.logger.catching(e);
-                    // Disconnect from channel if failed to create channel object
-                    bot.leave(channelName);
-                    return false;
-                }
-                bot.getChannels().put(channelName, channel);
-            } else {
-                channel = optional.get();
-            }
-            channel.join();
-
-            // Add channel to list of channels bot is in in config (if not bot channel)
-            if (!isBotChannel) {
-                Configs.editBotConfig(config -> config.getCurrentChannels().add(channelName));
-            }
-        } finally {
-            lock.unlock();
-        }
-        App.logger.info("Successfully joined channel: " + channelName);
-        return true;
+        return Control.getBot().channelManager().join(channelName, checks);
     }
 
     public static boolean leave(String channelName) {
-        final String channel = channelName.toLowerCase();
-        lock.lock();
-        try {
-            if (!in(channel)) {
-                App.logger.info("Not leaving channel '" + channel + "' - not in channel");
-                return false;
-            } else if (channel.equals(Control.getBot().getUserName())) {
-                App.logger.info("Not leaving channel '" + channel + "' - cannot leave bot channel");
-                return false;
-            }
-            App.logger.info("Leaving channel: " + channel);
-            get(channel).ifPresent(Channel::leave); // TODO possibly remove from channel list?
-            Configs.editBotConfig(config -> config.getCurrentChannels().remove(channel));
-            Control.getBot().leave(channel);
-        } finally {
-            lock.unlock();
-        }
-        return true;
+        return Control.getBot().channelManager().leave(channelName);
     }
 
     public static Set<String> list() {
-        return Control.getBot().getChannels().keySet();
+        return Control.getBot().channelManager().list();
     }
 
     public static boolean isBotChannel(String channel) {

--- a/src/main/java/com/github/otbproject/otbproject/channel/Channels.java
+++ b/src/main/java/com/github/otbproject/otbproject/channel/Channels.java
@@ -43,5 +43,4 @@ public class Channels {
     public static boolean isBotChannel(Channel channel) {
         return isBotChannel(channel.getName());
     }
-
 }

--- a/src/main/java/com/github/otbproject/otbproject/channel/CooldownManager.java
+++ b/src/main/java/com/github/otbproject/otbproject/channel/CooldownManager.java
@@ -1,0 +1,46 @@
+package com.github.otbproject.otbproject.channel;
+
+import net.jodah.expiringmap.ExpiringMap;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReadWriteLock;
+
+public class CooldownManager {
+    private final ExpiringMap<String, Boolean> cooldownSet = ExpiringMap.builder()
+            .variableExpiration()
+            .expirationPolicy(ExpiringMap.ExpirationPolicy.CREATED)
+            .build();
+    private final Channel channel;
+    private final ReadWriteLock channelLock;
+
+    CooldownManager(Channel channel, ReadWriteLock lock) {
+        this.channel = channel;
+        channelLock = lock;
+    }
+
+    public boolean isOnCooldown(String s) {
+        channelLock.readLock().lock();
+        try {
+            return cooldownSet.containsKey(s);
+        } finally {
+            channelLock.readLock().unlock();
+        }
+    }
+
+    public boolean addCooldown(String s, int time) {
+        channelLock.readLock().lock();
+        try {
+            if (channel.isInChannel()) {
+                cooldownSet.put(s, Boolean.TRUE, time, TimeUnit.SECONDS);
+                return true;
+            }
+            return false;
+        } finally {
+            channelLock.readLock().unlock();
+        }
+    }
+
+    void clearCooldowns() {
+        cooldownSet.clear();
+    }
+}

--- a/src/main/java/com/github/otbproject/otbproject/channel/ProxiedChannel.java
+++ b/src/main/java/com/github/otbproject/otbproject/channel/ProxiedChannel.java
@@ -6,7 +6,7 @@ public class ProxiedChannel {
 
     public ProxiedChannel(Channel channel) {
         this.channel = channel;
-        proxy = new ChannelProxy(channel);
+        proxy = new ChannelProxyImpl(channel);
     }
 
     public Channel channel() {

--- a/src/main/java/com/github/otbproject/otbproject/channel/ProxiedChannel.java
+++ b/src/main/java/com/github/otbproject/otbproject/channel/ProxiedChannel.java
@@ -1,0 +1,19 @@
+package com.github.otbproject.otbproject.channel;
+
+public class ProxiedChannel {
+    private final Channel channel;
+    private final ChannelProxy proxy;
+
+    public ProxiedChannel(Channel channel) {
+        this.channel = channel;
+        proxy = new ChannelProxy(channel);
+    }
+
+    public Channel channel() {
+        return channel;
+    }
+
+    public ChannelProxy proxy() {
+        return proxy;
+    }
+}

--- a/src/main/java/com/github/otbproject/otbproject/command/parser/CommandResponseParser.java
+++ b/src/main/java/com/github/otbproject/otbproject/command/parser/CommandResponseParser.java
@@ -1,8 +1,7 @@
 package com.github.otbproject.otbproject.command.parser;
 
 import com.github.otbproject.otbproject.bot.Control;
-import com.github.otbproject.otbproject.channel.Channel;
-import com.github.otbproject.otbproject.channel.Channels;
+import com.github.otbproject.otbproject.channel.ChannelProxy;
 import com.github.otbproject.otbproject.command.Command;
 import com.github.otbproject.otbproject.command.Commands;
 import com.github.otbproject.otbproject.config.Configs;
@@ -53,7 +52,7 @@ public class CommandResponseParser {
         // [[countof{{command}}]] - get count of another command without incrementing the other command's count
         registerTerm("countof", ((userNick, channel, count, args, term) -> {
             String commandName = getEmbeddedString(term, 1);
-            Optional<Channel> channelOptional = Channels.get(channel);
+            Optional<ChannelProxy> channelOptional = Control.getBot().channelManager().get(channel);
             if (channelOptional.isPresent()) {
                 Optional<Command> commandOptional = Commands.get(channelOptional.get().getMainDatabaseWrapper(), commandName);
                 if (commandOptional.isPresent()) {
@@ -66,7 +65,7 @@ public class CommandResponseParser {
         // [[quote.modifier]] - can have a modifier, but it's unclear why you want one
         registerTerm("quote", (userNick, channel, count, args, term) -> {
             String quoteNumStr = getEmbeddedString(term, 1);
-            Optional<Channel> channelOptional = Channels.get(channel);
+            Optional<ChannelProxy> channelOptional = Control.getBot().channelManager().get(channel);
             Optional<Quote> quoteOptional = Optional.empty();
             if (quoteNumStr.isEmpty()) {
                 if (channelOptional.isPresent()) {

--- a/src/main/java/com/github/otbproject/otbproject/command/scheduler/ChannelScheduleManager.java
+++ b/src/main/java/com/github/otbproject/otbproject/command/scheduler/ChannelScheduleManager.java
@@ -1,0 +1,67 @@
+package com.github.otbproject.otbproject.command.scheduler;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.locks.ReadWriteLock;
+
+public class ChannelScheduleManager {
+    private final ConcurrentHashMap<String, ScheduledFuture<?>> scheduledCommands;
+    private final ConcurrentHashMap<String, ScheduledFuture<?>> hourlyResetSchedules;
+    private final ReadWriteLock channelLock;
+
+    public ChannelScheduleManager(ConcurrentHashMap<String, ScheduledFuture<?>> scheduledCommands,
+                                  ConcurrentHashMap<String, ScheduledFuture<?>> hourlyResetSchedules,
+                                  ReadWriteLock channelLock) {
+        this.scheduledCommands = scheduledCommands;
+        this.hourlyResetSchedules = hourlyResetSchedules;
+        this.channelLock = channelLock;
+    }
+
+    void putCommandFuture(String command, ScheduledFuture<?> future) {
+        channelLock.readLock().lock();
+        try {
+            scheduledCommands.put(command, future);
+        } finally {
+            channelLock.readLock().unlock();
+        }
+    }
+
+    boolean hasCommandFuture(String command) {
+        return scheduledCommands.containsKey(command);
+    }
+
+    boolean removeCommandFuture(String command) {
+        ScheduledFuture<?> future;
+        channelLock.readLock().lock();
+        try {
+            future = scheduledCommands.remove(command);
+        } finally {
+            channelLock.readLock().unlock();
+        }
+        return (future != null) && future.cancel(true);
+    }
+
+    void putResetFuture(String command, ScheduledFuture<?> future) {
+        channelLock.readLock().lock();
+        try {
+            hourlyResetSchedules.put(command, future);
+        } finally {
+            channelLock.readLock().unlock();
+        }
+    }
+
+    boolean hasResetFuture(String command) {
+        return hourlyResetSchedules.containsKey(command);
+    }
+
+    boolean removeResetFuture(String command) {
+        ScheduledFuture<?> future;
+        channelLock.readLock().lock();
+        try {
+            future = hourlyResetSchedules.remove(command);
+        } finally {
+            channelLock.readLock().unlock();
+        }
+        return (future != null) && future.cancel(true);
+    }
+}

--- a/src/main/java/com/github/otbproject/otbproject/command/scheduler/ResetTask.java
+++ b/src/main/java/com/github/otbproject/otbproject/command/scheduler/ResetTask.java
@@ -1,20 +1,20 @@
 package com.github.otbproject.otbproject.command.scheduler;
 
 import com.github.otbproject.otbproject.App;
-import com.github.otbproject.otbproject.channel.Channel;
+import com.github.otbproject.otbproject.channel.ChannelProxy;
 
 import java.util.concurrent.TimeUnit;
 
 public class ResetTask implements Runnable {
 
-    private final Channel channel;
+    private final ChannelProxy channel;
     private final String command;
     private final long delay;
     private final long period;
     private final TimeUnit timeUnit;
     private final ScheduledCommand scheduledCommand;
 
-    public ResetTask(Channel channel, String command, long delay, long period, TimeUnit timeUnit) {
+    public ResetTask(ChannelProxy channel, String command, long delay, long period, TimeUnit timeUnit) {
         this.channel = channel;
         this.command = command;
         this.delay = delay;
@@ -25,14 +25,14 @@ public class ResetTask implements Runnable {
 
     @Override
     public void run() {
-        channel.removeCommandFuture(command);
+        channel.getScheduleManager().removeCommandFuture(command);
         try {
-            channel.putCommandFuture(command, channel.getScheduler().schedule(scheduledCommand, delay, period, timeUnit));
+            channel.getScheduleManager().putCommandFuture(command, channel.getScheduler().schedule(scheduledCommand, delay, period, timeUnit));
             App.logger.debug("Reset timing of scheduled command '" + command + "' for the beginning of the hour");
         } catch (SchedulingException e) {
             App.logger.catching(e);
             App.logger.error("Removing ResetTask for command that could not be scheduled: " + command);
-            channel.removeResetFuture(command);
+            channel.getScheduleManager().removeResetFuture(command);
         }
     }
 }

--- a/src/main/java/com/github/otbproject/otbproject/command/scheduler/ScheduledCommand.java
+++ b/src/main/java/com/github/otbproject/otbproject/command/scheduler/ScheduledCommand.java
@@ -2,7 +2,7 @@ package com.github.otbproject.otbproject.command.scheduler;
 
 import com.github.otbproject.otbproject.App;
 import com.github.otbproject.otbproject.bot.Control;
-import com.github.otbproject.otbproject.channel.Channel;
+import com.github.otbproject.otbproject.channel.ChannelProxy;
 import com.github.otbproject.otbproject.messages.receive.PackagedMessage;
 import com.github.otbproject.otbproject.messages.send.MessagePriority;
 import com.github.otbproject.otbproject.user.UserLevel;
@@ -11,10 +11,10 @@ import java.util.Objects;
 
 public class ScheduledCommand implements Runnable {
 
-    private final Channel channel;
+    private final ChannelProxy channel;
     private final PackagedMessage packagedMessage;
 
-    public ScheduledCommand(Channel channel, String command) {
+    public ScheduledCommand(ChannelProxy channel, String command) {
         Objects.requireNonNull(channel, command);
         this.channel = channel;
         packagedMessage = new PackagedMessage(command, Control.getBot().getUserName(), channel.getName(), UserLevel.INTERNAL, MessagePriority.DEFAULT);

--- a/src/main/java/com/github/otbproject/otbproject/config/Configs.java
+++ b/src/main/java/com/github/otbproject/otbproject/config/Configs.java
@@ -1,9 +1,9 @@
 package com.github.otbproject.otbproject.config;
 
 import com.github.otbproject.otbproject.App;
-import com.github.otbproject.otbproject.channel.Channel;
+import com.github.otbproject.otbproject.bot.Control;
 import com.github.otbproject.otbproject.channel.ChannelNotFoundException;
-import com.github.otbproject.otbproject.channel.Channels;
+import com.github.otbproject.otbproject.channel.ChannelProxy;
 import com.github.otbproject.otbproject.fs.FSUtil;
 
 import java.io.File;
@@ -61,10 +61,10 @@ public class Configs {
     }
 
     public static void editChannelConfig(String channel, Consumer<ChannelConfig> consumer) throws ChannelNotFoundException {
-        Channels.getOrThrow(channel).editConfig(consumer);
+        Control.getBot().channelManager().getOrThrow(channel).editConfig(consumer);
     }
 
-    public static void editChannelConfig(Channel channel, Consumer<ChannelConfig> consumer) {
+    public static void editChannelConfig(ChannelProxy channel, Consumer<ChannelConfig> consumer) {
         channel.editConfig(consumer);
     }
 
@@ -126,10 +126,10 @@ public class Configs {
     }
 
     public static <R> R getFromChannelConfig(String channel, Function<ChannelConfig, R> function) throws ChannelNotFoundException {
-        return Channels.getOrThrow(channel).getFromConfig(function);
+        return Control.getBot().channelManager().getOrThrow(channel).getFromConfig(function);
     }
 
-    public static <R> R getFromChannelConfig(Channel channel, Function<ChannelConfig, R> function) {
+    public static <R> R getFromChannelConfig(ChannelProxy channel, Function<ChannelConfig, R> function) {
         return channel.getFromConfig(function);
     }
 

--- a/src/main/java/com/github/otbproject/otbproject/gui/GuiController.java
+++ b/src/main/java/com/github/otbproject/otbproject/gui/GuiController.java
@@ -1,8 +1,9 @@
 package com.github.otbproject.otbproject.gui;
 
+import com.github.otbproject.otbproject.bot.Bot;
 import com.github.otbproject.otbproject.bot.Control;
 import com.github.otbproject.otbproject.channel.Channel;
-import com.github.otbproject.otbproject.channel.Channels;
+import com.github.otbproject.otbproject.channel.ChannelProxy;
 import com.github.otbproject.otbproject.cli.commands.CmdParser;
 import com.github.otbproject.otbproject.command.Aliases;
 import com.github.otbproject.otbproject.command.Commands;
@@ -123,10 +124,10 @@ public class GuiController {
                             break;
                         case CmdParser.EXEC:
                         case CmdParser.RESET:
-                            tabComplete(parts, 1, Channels.list());
+                            tabComplete(parts, 1, Control.getBot().channelManager().list());
                             break;
                         case CmdParser.LEAVECHANNEL:
-                            tabComplete(parts, 1, Channels.list(), s -> !Channels.isBotChannel(s));
+                            tabComplete(parts, 1, Control.getBot().channelManager().list(), s -> !Channel.isBotChannel(s));
                             break;
                         case CmdParser.HELP:
                             tabComplete(parts, 1, CmdParser.getCommands());
@@ -135,13 +136,14 @@ public class GuiController {
                             // defaults to no tab completion for first argument
                     }
                 } else if (parts.size() == 3 && parts.get(0).equals(CmdParser.EXEC)) {
-                    Optional<Channel> optional = Channels.get(parts.get(1));
+                    Bot bot = Control.getBot();
+                    Optional<ChannelProxy> optional = bot.channelManager().get(parts.get(1));
                     if (optional.isPresent() && optional.get().isInChannel()) {
-                        Channel channel = optional.get();
+                        ChannelProxy channel = optional.get();
                         List<String> list = Commands.getCommands(channel.getMainDatabaseWrapper());
                         list = (list == null) ? new ArrayList<>() : list;
                         addIfNotNull(list, Aliases.getAliases(channel.getMainDatabaseWrapper()));
-                        if (Channels.isBotChannel(channel)) {
+                        if (Channel.isBotChannel(channel.getName())) {
                             addIfNotNull(list, Commands.getCommands(Control.getBot().getBotDB()));
                             addIfNotNull(list, Aliases.getAliases(Control.getBot().getBotDB()));
                         }

--- a/src/main/java/com/github/otbproject/otbproject/messages/receive/MessageHandler.java
+++ b/src/main/java/com/github/otbproject/otbproject/messages/receive/MessageHandler.java
@@ -1,10 +1,10 @@
 package com.github.otbproject.otbproject.messages.receive;
 
-import com.github.otbproject.otbproject.channel.Channel;
+import com.github.otbproject.otbproject.channel.ChannelProxy;
 
 @FunctionalInterface
 public interface MessageHandler {
-    void onMessage(Channel channel, PackagedMessage packagedMessage, boolean timedOut);
+    void onMessage(ChannelProxy channel, PackagedMessage packagedMessage, boolean timedOut);
 
     default MessageHandler andThen(MessageHandler after) {
         return (channel, packagedMessage, timedOut) -> {

--- a/src/main/java/com/github/otbproject/otbproject/proc/TimeoutProcessor.java
+++ b/src/main/java/com/github/otbproject/otbproject/proc/TimeoutProcessor.java
@@ -1,7 +1,7 @@
 package com.github.otbproject.otbproject.proc;
 
 import com.github.otbproject.otbproject.bot.Control;
-import com.github.otbproject.otbproject.channel.Channel;
+import com.github.otbproject.otbproject.channel.ChannelProxy;
 import com.github.otbproject.otbproject.filter.FilterAction;
 import com.github.otbproject.otbproject.filter.FilterGroup;
 import com.github.otbproject.otbproject.filter.FilterProcessor;
@@ -12,7 +12,7 @@ import com.github.otbproject.otbproject.user.UserLevel;
 import java.util.Optional;
 
 public class TimeoutProcessor {
-    public static boolean doTimeouts(Channel channel, PackagedMessage packagedMessage) {
+    public static boolean doTimeouts(ChannelProxy channel, PackagedMessage packagedMessage) {
         // TODO implement and remove if statement
         if (false) { // So I can work on an implementation without changing behaviour
             Optional<FilterGroup> optional = FilterProcessor.process(channel.getFilterMap(), packagedMessage.message, packagedMessage.userLevel);
@@ -47,7 +47,7 @@ public class TimeoutProcessor {
         }
     }
 
-    private static void sendFilterMessage(Channel channel, PackagedMessage incomingMessage, FilterGroup filterGroup) {
+    private static void sendFilterMessage(ChannelProxy channel, PackagedMessage incomingMessage, FilterGroup filterGroup) {
         // TODO handle message for timeout
         String responseCommand = "";
         switch (filterGroup.getAction()) {

--- a/src/main/java/com/github/otbproject/otbproject/util/ScriptHelper.java
+++ b/src/main/java/com/github/otbproject/otbproject/util/ScriptHelper.java
@@ -2,6 +2,7 @@ package com.github.otbproject.otbproject.util;
 
 import com.github.otbproject.otbproject.App;
 import com.github.otbproject.otbproject.channel.ChannelNotFoundException;
+import com.github.otbproject.otbproject.channel.ChannelProxy;
 import com.github.otbproject.otbproject.channel.Channels;
 import com.github.otbproject.otbproject.messages.internal.InternalMessageSender;
 import com.github.otbproject.otbproject.messages.receive.PackagedMessage;
@@ -23,5 +24,9 @@ public class ScriptHelper {
             MessageOut messageOut = new MessageOut(message, priority);
             Channels.getOrThrow(channelName).sendMessage(messageOut);
         }
+    }
+
+    public static void sendMessage(ChannelProxy channelProxy, String message, MessagePriority priority) throws ChannelNotFoundException {
+        channelProxy.sendMessage(new MessageOut(message, priority));
     }
 }

--- a/src/main/java/com/github/otbproject/otbproject/util/ScriptHelper.java
+++ b/src/main/java/com/github/otbproject/otbproject/util/ScriptHelper.java
@@ -1,9 +1,9 @@
 package com.github.otbproject.otbproject.util;
 
 import com.github.otbproject.otbproject.App;
+import com.github.otbproject.otbproject.bot.Control;
 import com.github.otbproject.otbproject.channel.ChannelNotFoundException;
 import com.github.otbproject.otbproject.channel.ChannelProxy;
-import com.github.otbproject.otbproject.channel.Channels;
 import com.github.otbproject.otbproject.messages.internal.InternalMessageSender;
 import com.github.otbproject.otbproject.messages.receive.PackagedMessage;
 import com.github.otbproject.otbproject.messages.send.MessageOut;
@@ -14,7 +14,7 @@ public class ScriptHelper {
     public static void runCommand(String message, String user, String channelName, String destinationChannel, MessagePriority priority) throws ChannelNotFoundException {
         App.logger.debug("Processing message as command: " + message);
         PackagedMessage packagedMessage = new PackagedMessage(message, user, channelName, destinationChannel, UserLevel.INTERNAL, priority);
-        Channels.getOrThrow(channelName).receiveMessage(packagedMessage);
+        Control.getBot().channelManager().getOrThrow(channelName).receiveMessage(packagedMessage);
     }
 
     public static void sendMessage(String channelName, String message, MessagePriority priority) throws ChannelNotFoundException {
@@ -22,7 +22,7 @@ public class ScriptHelper {
             InternalMessageSender.send(channelName.substring(InternalMessageSender.DESTINATION_PREFIX.length()), message, "CmdExec");
         } else {
             MessageOut messageOut = new MessageOut(message, priority);
-            Channels.getOrThrow(channelName).sendMessage(messageOut);
+            Control.getBot().channelManager().getOrThrow(channelName).sendMessage(messageOut);
         }
     }
 


### PR DESCRIPTION
Channel APIs used to have significant encapsulation problems, which allowed clients to accidentally join or leave channels incompletely. This PR deprecates old methods which contributed to those encapsulation problems, and replaces them with new APIs which delegate channel joining and leaving to `Control.getBot().channelManager()`.

See the commit messages for more details of the changes.