### PR TITLE
Fix concurrency problem changing Service

### DIFF
--- a/src/main/java/com/github/otbproject/otbproject/bot/Control.java
+++ b/src/main/java/com/github/otbproject/otbproject/bot/Control.java
@@ -173,7 +173,7 @@ public class Control {
     }
 
     private static void loadConfigs() {
-        Configs.getGeneralConfig().update();
+        Configs.getGeneralConfig().updateAndAwait();
         Configs.reloadAccount();
     }
 

--- a/src/main/java/com/github/otbproject/otbproject/config/UpdatingConfig.java
+++ b/src/main/java/com/github/otbproject/otbproject/config/UpdatingConfig.java
@@ -67,7 +67,7 @@ public class UpdatingConfig<T> extends WrappedConfigImpl<T> {
         }
         MONITOR.addObserver(observer);
         monitoring = true;
-        update();
+        updateLater();
         App.logger.debug("Started monitoring file: " + path);
         return true;
     }
@@ -164,8 +164,13 @@ public class UpdatingConfig<T> extends WrappedConfigImpl<T> {
         }
 
         @Override
-        public void update() {
-            UpdatingConfig.this.update();
+        public void updateLater() {
+            UpdatingConfig.this.updateLater();
+        }
+
+        @Override
+        public void updateAndAwait() {
+            UpdatingConfig.this.updateAndAwait();
         }
     }
 }

--- a/src/main/java/com/github/otbproject/otbproject/config/WrappedConfig.java
+++ b/src/main/java/com/github/otbproject/otbproject/config/WrappedConfig.java
@@ -15,7 +15,9 @@ public interface WrappedConfig<T> {
 
     void edit(Consumer<T> consumer);
 
-    void update();
+    void updateLater();
+
+    void updateAndAwait();
 
     static <T> WrappedConfig<T> of(Class<T> tClass, String path, Supplier<T> defaultConfigSupplier) {
         return new WrappedConfigImpl<>(tClass, path, defaultConfigSupplier);


### PR DESCRIPTION
Fixed problems where Configs::getAccount would return an Account
with the wrong data due to either the private 'account' field not
being propogated to other threads, or because the updated Service
in the 'generalConfig' field was not being propogated to other
threads.

Added WrappedConfig::updateAndAwait, and refactored ::update to
::updateLater. This was done to fix a problem in Control where,
when reloading the GeneralConfig, it would queue an update and then
update the Account based on the GeneralConfig when the latter might
not have actually been updated yet.