### PR TITLE
Add basics of event framework

### DIFF
--- a/src/main/java/com/github/otbproject/otbproject/bot/AbstractServiceChannel.java
+++ b/src/main/java/com/github/otbproject/otbproject/bot/AbstractServiceChannel.java
@@ -4,7 +4,7 @@ import com.github.otbproject.otbproject.event.ChannelStateChangeEvent;
 
 import java.util.concurrent.atomic.AtomicReference;
 
-public class AbstractServiceChannel {
+public abstract class AbstractServiceChannel {
     protected final AtomicReference<ChannelState> state = new AtomicReference<>(ChannelState.DEAD);
 
     protected void updateChannelState(ChannelState newState) {

--- a/src/main/java/com/github/otbproject/otbproject/bot/AbstractServiceChannel.java
+++ b/src/main/java/com/github/otbproject/otbproject/bot/AbstractServiceChannel.java
@@ -1,0 +1,20 @@
+package com.github.otbproject.otbproject.bot;
+
+import com.github.otbproject.otbproject.event.ChannelStateChangeEvent;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+public class AbstractServiceChannel {
+    protected final AtomicReference<ChannelState> state = new AtomicReference<>(ChannelState.DEAD);
+
+    protected void updateChannelState(ChannelState newState) {
+        if (state.getAndSet(newState) != newState) {
+            fireChannelStateChangeEvent(newState);
+        }
+    }
+
+    private void fireChannelStateChangeEvent(ChannelState newState) {
+        // TODO implement once events are implemented
+        //new ChannelStateChangeEvent(newState);
+    }
+}

--- a/src/main/java/com/github/otbproject/otbproject/bot/Bot.java
+++ b/src/main/java/com/github/otbproject/otbproject/bot/Bot.java
@@ -6,6 +6,7 @@ import com.github.otbproject.otbproject.channel.ChannelProxy;
 import com.github.otbproject.otbproject.database.DatabaseWrapper;
 import com.github.otbproject.otbproject.messages.receive.PackagedMessage;
 import com.github.otbproject.otbproject.messages.receive.MessageHandler;
+import com.google.common.eventbus.EventBus;
 
 import java.util.concurrent.ConcurrentMap;
 
@@ -47,7 +48,5 @@ public interface Bot {
 
     boolean removeTimeout(String channelName, String user);
 
-    void onMessage(MessageHandler messageHandler);
-
-    void invokeMessageHandlers(ChannelProxy channel, PackagedMessage message, boolean timedOut);
+    EventBus eventBus();
 }

--- a/src/main/java/com/github/otbproject/otbproject/bot/ChannelState.java
+++ b/src/main/java/com/github/otbproject/otbproject/bot/ChannelState.java
@@ -1,0 +1,5 @@
+package com.github.otbproject.otbproject.bot;
+
+public enum ChannelState {
+    LIVE, DEAD
+}

--- a/src/main/java/com/github/otbproject/otbproject/bot/beam/BeamMessageHandler.java
+++ b/src/main/java/com/github/otbproject/otbproject/bot/beam/BeamMessageHandler.java
@@ -4,6 +4,7 @@ import com.github.otbproject.otbproject.App;
 import com.github.otbproject.otbproject.bot.BotUtil;
 import com.github.otbproject.otbproject.bot.Control;
 import com.github.otbproject.otbproject.channel.*;
+import com.github.otbproject.otbproject.event.ChannelMessageEvent;
 import com.github.otbproject.otbproject.messages.receive.PackagedMessage;
 import com.github.otbproject.otbproject.messages.send.MessagePriority;
 import com.github.otbproject.otbproject.proc.TimeoutProcessor;
@@ -83,7 +84,7 @@ public class BeamMessageHandler implements EventHandler<IncomingMessageEvent> {
                 ChannelProxy channel = optional.get();
                 UserLevel userLevel = UserLevels.getUserLevel(channel.getMainDatabaseWrapper(), channelName, userNameLower);
                 PackagedMessage packagedMessage = new PackagedMessage(message, userNameLower, channelName, userLevel, MessagePriority.DEFAULT);
-                bot.invokeMessageHandlers(channel, packagedMessage, TimeoutProcessor.doTimeouts(channel, packagedMessage));
+                bot.eventBus().post(new ChannelMessageEvent(channel, packagedMessage, TimeoutProcessor.doTimeouts(channel, packagedMessage)));
             } else {
                 App.logger.error("Channel: " + channelName + " appears not to exist");
             }

--- a/src/main/java/com/github/otbproject/otbproject/bot/irc/IrcListener.java
+++ b/src/main/java/com/github/otbproject/otbproject/bot/irc/IrcListener.java
@@ -7,6 +7,7 @@ import com.github.otbproject.otbproject.channel.ChannelProxy;
 import com.github.otbproject.otbproject.channel.JoinCheck;
 import com.github.otbproject.otbproject.config.BotConfig;
 import com.github.otbproject.otbproject.config.Configs;
+import com.github.otbproject.otbproject.event.ChannelMessageEvent;
 import com.github.otbproject.otbproject.messages.receive.PackagedMessage;
 import com.github.otbproject.otbproject.messages.send.MessagePriority;
 import com.github.otbproject.otbproject.proc.TimeoutProcessor;
@@ -34,24 +35,24 @@ class IrcListener extends ListenerAdapter {
 
         String message = event.getMessage();
         TwitchBot bot = (TwitchBot) Control.bot();
-        if(event.getTags().get("subscriber") != null && event.getTags().get("subscriber").equalsIgnoreCase("1")){
-            bot.subscriberStorage.put(channelName,user);
+        if (event.getTags().get("subscriber") != null && event.getTags().get("subscriber").equalsIgnoreCase("1")) {
+            bot.subscriberStorage.put(channelName, user);
         }
         UserLevel userLevel = UserLevels.getUserLevel(channel.getMainDatabaseWrapper(), channelName, user);
         PackagedMessage packagedMessage = new PackagedMessage(message, user, channelName, userLevel, MessagePriority.DEFAULT);
-        bot.invokeMessageHandlers(channel, packagedMessage, TimeoutProcessor.doTimeouts(channel, packagedMessage));
+        bot.eventBus().post(new ChannelMessageEvent(channel, packagedMessage, TimeoutProcessor.doTimeouts(channel, packagedMessage)));
     }
 
     @Override
     public void onJoin(JoinEvent event) {
-        if(event.getUser().equals(event.getBot().getUserBot())) {
-            ((TwitchBot) Control.bot()).addJoined(IRCHelper.getInternalChannelName(event.getChannel().getName()),event.getChannel());
+        if (event.getUser().equals(event.getBot().getUserBot())) {
+            ((TwitchBot) Control.bot()).addJoined(IRCHelper.getInternalChannelName(event.getChannel().getName()), event.getChannel());
         }
     }
 
     @Override
     public void onPart(PartEvent event) {
-        if(event.getUser().equals(event.getBot().getUserBot())) {
+        if (event.getUser().equals(event.getBot().getUserBot())) {
             ((TwitchBot) Control.bot()).removeJoined(IRCHelper.getInternalChannelName(event.getChannel().getName()));
         }
     }

--- a/src/main/java/com/github/otbproject/otbproject/bot/nullbot/NullBot.java
+++ b/src/main/java/com/github/otbproject/otbproject/bot/nullbot/NullBot.java
@@ -9,6 +9,7 @@ import com.github.otbproject.otbproject.channel.ProxiedChannel;
 import com.github.otbproject.otbproject.database.DatabaseWrapper;
 import com.github.otbproject.otbproject.messages.receive.MessageHandler;
 import com.github.otbproject.otbproject.messages.receive.PackagedMessage;
+import com.google.common.eventbus.EventBus;
 
 import java.util.concurrent.ConcurrentMap;
 
@@ -16,6 +17,22 @@ public class NullBot implements Bot {
     private static final ConcurrentMap<String, ProxiedChannel> CHANNELS = new EmptyConcurrentMap<>();
     private static final ChannelManager channelManager = new ChannelManager(CHANNELS);
     private static final DatabaseWrapper DATABASE_WRAPPER = new EmptyDatabaseWrapper();
+    private static final EventBus NULL_EVENT_BUS = new EventBus("null-bus") {
+        @Override
+        public void post(Object event) {
+            // NO-OP
+        }
+
+        @Override
+        public void register(Object object) {
+            // NO-OP
+        }
+
+        @Override
+        public void unregister(Object object) {
+            //NO-OP
+        }
+    };
     public static final NullBot INSTANCE = new NullBot();
 
     @Deprecated // TODO REMOVE
@@ -116,12 +133,7 @@ public class NullBot implements Bot {
     }
 
     @Override
-    public void onMessage(MessageHandler messageHandler) {
-        // NO-OP
-    }
-
-    @Override
-    public void invokeMessageHandlers(ChannelProxy channel, PackagedMessage message, boolean timedOut) {
-        // NO-OP
+    public EventBus eventBus() {
+        return NULL_EVENT_BUS;
     }
 }

--- a/src/main/java/com/github/otbproject/otbproject/command/scheduler/ScheduledCommand.java
+++ b/src/main/java/com/github/otbproject/otbproject/command/scheduler/ScheduledCommand.java
@@ -22,7 +22,7 @@ public class ScheduledCommand implements Runnable {
 
     @Override
     public void run() {
-        App.logger.debug("Attempting to run scheduled command '" + packagedMessage.message + "' in channel: " + channel.getName());
+        App.logger.debug("Attempting to run scheduled command '" + packagedMessage.getMessage() + "' in channel: " + channel.getName());
         channel.receiveMessage(packagedMessage);
     }
 }

--- a/src/main/java/com/github/otbproject/otbproject/event/BotStartEvent.java
+++ b/src/main/java/com/github/otbproject/otbproject/event/BotStartEvent.java
@@ -1,0 +1,15 @@
+package com.github.otbproject.otbproject.event;
+
+import com.github.otbproject.otbproject.config.Service;
+
+public class BotStartEvent {
+    private final Service service;
+
+    public BotStartEvent(Service service) {
+        this.service = service;
+    }
+
+    public Service getService() {
+        return service;
+    }
+}

--- a/src/main/java/com/github/otbproject/otbproject/event/BotStopEvent.java
+++ b/src/main/java/com/github/otbproject/otbproject/event/BotStopEvent.java
@@ -1,0 +1,15 @@
+package com.github.otbproject.otbproject.event;
+
+import com.github.otbproject.otbproject.config.Service;
+
+public class BotStopEvent {
+    private final Service service;
+
+    public BotStopEvent(Service service) {
+        this.service = service;
+    }
+
+    public Service getService() {
+        return service;
+    }
+}

--- a/src/main/java/com/github/otbproject/otbproject/event/ChannelJoinEvent.java
+++ b/src/main/java/com/github/otbproject/otbproject/event/ChannelJoinEvent.java
@@ -1,0 +1,15 @@
+package com.github.otbproject.otbproject.event;
+
+import com.github.otbproject.otbproject.channel.Channel;
+
+public class ChannelJoinEvent {
+    private final Channel channel;
+
+    public ChannelJoinEvent(Channel channel) {
+        this.channel = channel;
+    }
+
+    public Channel getChannel() {
+        return channel;
+    }
+}

--- a/src/main/java/com/github/otbproject/otbproject/event/ChannelLeaveEvent.java
+++ b/src/main/java/com/github/otbproject/otbproject/event/ChannelLeaveEvent.java
@@ -1,0 +1,15 @@
+package com.github.otbproject.otbproject.event;
+
+import com.github.otbproject.otbproject.channel.Channel;
+
+public class ChannelLeaveEvent {
+    private final Channel channel;
+
+    public ChannelLeaveEvent(Channel channel) {
+        this.channel = channel;
+    }
+
+    public Channel getChannel() {
+        return channel;
+    }
+}

--- a/src/main/java/com/github/otbproject/otbproject/event/ChannelMessageEvent.java
+++ b/src/main/java/com/github/otbproject/otbproject/event/ChannelMessageEvent.java
@@ -1,0 +1,28 @@
+package com.github.otbproject.otbproject.event;
+
+import com.github.otbproject.otbproject.channel.ChannelProxy;
+import com.github.otbproject.otbproject.messages.receive.PackagedMessage;
+
+public class ChannelMessageEvent {
+    private final ChannelProxy channel;
+    private final PackagedMessage message;
+    private final boolean filtered;
+
+    public ChannelMessageEvent(ChannelProxy channel, PackagedMessage message, boolean filtered) {
+        this.channel = channel;
+        this.message = message;
+        this.filtered = filtered;
+    }
+
+    public ChannelProxy getChannel() {
+        return channel;
+    }
+
+    public boolean isFiltered() {
+        return filtered;
+    }
+
+    public PackagedMessage getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/com/github/otbproject/otbproject/event/ChannelStateChangeEvent.java
+++ b/src/main/java/com/github/otbproject/otbproject/event/ChannelStateChangeEvent.java
@@ -1,0 +1,15 @@
+package com.github.otbproject.otbproject.event;
+
+import com.github.otbproject.otbproject.bot.ChannelState;
+
+public class ChannelStateChangeEvent {
+    private final ChannelState newState;
+
+    public ChannelStateChangeEvent(ChannelState newState) {
+        this.newState = newState;
+    }
+
+    public ChannelState getNewState() {
+        return newState;
+    }
+}

--- a/src/main/java/com/github/otbproject/otbproject/event/ServiceChannelConnectEvent.java
+++ b/src/main/java/com/github/otbproject/otbproject/event/ServiceChannelConnectEvent.java
@@ -1,0 +1,13 @@
+package com.github.otbproject.otbproject.event;
+
+public class ServiceChannelConnectEvent {
+    private final String channel;
+
+    public ServiceChannelConnectEvent(String channel) {
+        this.channel = channel;
+    }
+
+    public String getChannel() {
+        return channel;
+    }
+}

--- a/src/main/java/com/github/otbproject/otbproject/event/ServiceChannelDisconnectEvent.java
+++ b/src/main/java/com/github/otbproject/otbproject/event/ServiceChannelDisconnectEvent.java
@@ -1,0 +1,13 @@
+package com.github.otbproject.otbproject.event;
+
+public class ServiceChannelDisconnectEvent {
+    private final String channel;
+
+    public ServiceChannelDisconnectEvent(String channel) {
+        this.channel = channel;
+    }
+
+    public String getChannel() {
+        return channel;
+    }
+}

--- a/src/main/java/com/github/otbproject/otbproject/event/UserFollowStateChangeEvent.java
+++ b/src/main/java/com/github/otbproject/otbproject/event/UserFollowStateChangeEvent.java
@@ -1,0 +1,16 @@
+package com.github.otbproject.otbproject.event;
+
+import com.github.otbproject.otbproject.event.state.FollowState;
+
+public class UserFollowStateChangeEvent extends UserServiceChannelEvent {
+    private final FollowState followState;
+
+    public UserFollowStateChangeEvent(String channel, String user, FollowState followState) {
+        super(channel, user);
+        this.followState = followState;
+    }
+
+    public FollowState getFollowState() {
+        return followState;
+    }
+}

--- a/src/main/java/com/github/otbproject/otbproject/event/UserJoinEvent.java
+++ b/src/main/java/com/github/otbproject/otbproject/event/UserJoinEvent.java
@@ -1,0 +1,19 @@
+package com.github.otbproject.otbproject.event;
+
+public class UserJoinEvent {
+    private final String channel;
+    private final String user;
+
+    public UserJoinEvent(String channel, String user) {
+        this.channel = channel;
+        this.user = user;
+    }
+
+    public String getChannel() {
+        return channel;
+    }
+
+    public String getUser() {
+        return user;
+    }
+}

--- a/src/main/java/com/github/otbproject/otbproject/event/UserJoinEvent.java
+++ b/src/main/java/com/github/otbproject/otbproject/event/UserJoinEvent.java
@@ -1,19 +1,7 @@
 package com.github.otbproject.otbproject.event;
 
-public class UserJoinEvent {
-    private final String channel;
-    private final String user;
-
+public class UserJoinEvent extends UserServiceChannelEvent {
     public UserJoinEvent(String channel, String user) {
-        this.channel = channel;
-        this.user = user;
-    }
-
-    public String getChannel() {
-        return channel;
-    }
-
-    public String getUser() {
-        return user;
+        super(channel, user);
     }
 }

--- a/src/main/java/com/github/otbproject/otbproject/event/UserLeaveEvent.java
+++ b/src/main/java/com/github/otbproject/otbproject/event/UserLeaveEvent.java
@@ -1,0 +1,19 @@
+package com.github.otbproject.otbproject.event;
+
+public class UserLeaveEvent {
+    private final String channel;
+    private final String user;
+
+    public UserLeaveEvent(String channel, String user) {
+        this.channel = channel;
+        this.user = user;
+    }
+
+    public String getChannel() {
+        return channel;
+    }
+
+    public String getUser() {
+        return user;
+    }
+}

--- a/src/main/java/com/github/otbproject/otbproject/event/UserLeaveEvent.java
+++ b/src/main/java/com/github/otbproject/otbproject/event/UserLeaveEvent.java
@@ -1,19 +1,7 @@
 package com.github.otbproject.otbproject.event;
 
-public class UserLeaveEvent {
-    private final String channel;
-    private final String user;
-
+public class UserLeaveEvent extends UserServiceChannelEvent {
     public UserLeaveEvent(String channel, String user) {
-        this.channel = channel;
-        this.user = user;
-    }
-
-    public String getChannel() {
-        return channel;
-    }
-
-    public String getUser() {
-        return user;
+        super(channel, user);
     }
 }

--- a/src/main/java/com/github/otbproject/otbproject/event/UserServiceChannelEvent.java
+++ b/src/main/java/com/github/otbproject/otbproject/event/UserServiceChannelEvent.java
@@ -1,0 +1,19 @@
+package com.github.otbproject.otbproject.event;
+
+abstract class UserServiceChannelEvent {
+    private final String channel;
+    private final String user;
+
+    public UserServiceChannelEvent(String channel, String user) {
+        this.channel = channel;
+        this.user = user;
+    }
+
+    public String getChannel() {
+        return channel;
+    }
+
+    public String getUser() {
+        return user;
+    }
+}

--- a/src/main/java/com/github/otbproject/otbproject/event/UserSubscriptionStateChangeEvent.java
+++ b/src/main/java/com/github/otbproject/otbproject/event/UserSubscriptionStateChangeEvent.java
@@ -1,0 +1,16 @@
+package com.github.otbproject.otbproject.event;
+
+import com.github.otbproject.otbproject.event.state.SubscriptionState;
+
+public class UserSubscriptionStateChangeEvent extends UserServiceChannelEvent {
+    private final SubscriptionState subscriptionState;
+
+    public UserSubscriptionStateChangeEvent(String channel, String user, SubscriptionState subscriptionState) {
+        super(channel, user);
+        this.subscriptionState = subscriptionState;
+    }
+
+    public SubscriptionState getSubscriptionState() {
+        return subscriptionState;
+    }
+}

--- a/src/main/java/com/github/otbproject/otbproject/event/state/FollowState.java
+++ b/src/main/java/com/github/otbproject/otbproject/event/state/FollowState.java
@@ -1,0 +1,5 @@
+package com.github.otbproject.otbproject.event.state;
+
+public enum FollowState {
+    FOLLOW, UNFOLLOW
+}

--- a/src/main/java/com/github/otbproject/otbproject/event/state/SubscriptionState.java
+++ b/src/main/java/com/github/otbproject/otbproject/event/state/SubscriptionState.java
@@ -1,0 +1,5 @@
+package com.github.otbproject.otbproject.event.state;
+
+public enum SubscriptionState {
+    SUBSCRIBE, RENEW, UNSUBSCRIBE
+}

--- a/src/main/java/com/github/otbproject/otbproject/messages/receive/PackagedMessage.java
+++ b/src/main/java/com/github/otbproject/otbproject/messages/receive/PackagedMessage.java
@@ -4,12 +4,12 @@ import com.github.otbproject.otbproject.messages.send.MessagePriority;
 import com.github.otbproject.otbproject.user.UserLevel;
 
 public class PackagedMessage {
-    public final String message;
-    public final String user;
-    public final String channel;
-    public final String destinationChannel;
-    public final UserLevel userLevel;
-    public final MessagePriority messagePriority;
+    private final String message;
+    private final String user;
+    private final String channel;
+    private final String destinationChannel;
+    private final UserLevel userLevel;
+    private final MessagePriority messagePriority;
 
     public PackagedMessage(String message, String user, String channel, String destinationChannel, UserLevel userLevel, MessagePriority messagePriority) {
         this.message = message;
@@ -22,5 +22,29 @@ public class PackagedMessage {
 
     public PackagedMessage(String message, String user, String channel, UserLevel userLevel, MessagePriority messagePriority) {
         this(message, user, channel, channel, userLevel, messagePriority);
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public String getUser() {
+        return user;
+    }
+
+    public String getChannel() {
+        return channel;
+    }
+
+    public String getDestinationChannel() {
+        return destinationChannel;
+    }
+
+    public UserLevel getUserLevel() {
+        return userLevel;
+    }
+
+    public MessagePriority getMessagePriority() {
+        return messagePriority;
     }
 }

--- a/src/main/java/com/github/otbproject/otbproject/proc/TimeoutProcessor.java
+++ b/src/main/java/com/github/otbproject/otbproject/proc/TimeoutProcessor.java
@@ -15,7 +15,7 @@ public class TimeoutProcessor {
     public static boolean doTimeouts(ChannelProxy channel, PackagedMessage packagedMessage) {
         // TODO implement and remove if statement
         if (false) { // So I can work on an implementation without changing behaviour
-            Optional<FilterGroup> optional = FilterProcessor.process(channel.getFilterMap(), packagedMessage.message, packagedMessage.userLevel);
+            Optional<FilterGroup> optional = FilterProcessor.process(channel.getFilterMap(), packagedMessage.getMessage(), packagedMessage.getUserLevel());
             if (optional.isPresent()) {
                 FilterGroup filterGroup = optional.get();
                 performFilterAction(packagedMessage, filterGroup.getAction());
@@ -31,16 +31,16 @@ public class TimeoutProcessor {
     private static void performFilterAction(PackagedMessage packagedMessage, FilterAction action) {
         switch (action) {
             case BAN:
-                Control.bot().ban(packagedMessage.channel, packagedMessage.user);
+                Control.bot().ban(packagedMessage.getChannel(), packagedMessage.getUser());
                 break;
             case TIMEOUT:
-                Control.bot().timeout(packagedMessage.channel, packagedMessage.user, 600); // TODO get actual time from somewhere (config?)
+                Control.bot().timeout(packagedMessage.getChannel(), packagedMessage.getUser(), 600); // TODO get actual time from somewhere (config?)
                 break;
             case STRIKE:
                 // TODO handle strike number
                 break;
             case PURGE:
-                Control.bot().timeout(packagedMessage.channel, packagedMessage.user, 1);
+                Control.bot().timeout(packagedMessage.getChannel(), packagedMessage.getUser(), 1);
                 break;
             default:
                 // No action to perform by default
@@ -61,7 +61,7 @@ public class TimeoutProcessor {
                 // TODO handle strike number
                 break;
         }
-        PackagedMessage responseMessage = new PackagedMessage(responseCommand, incomingMessage.user, incomingMessage.channel, incomingMessage.destinationChannel, UserLevel.INTERNAL, MessagePriority.LOW);
+        PackagedMessage responseMessage = new PackagedMessage(responseCommand, incomingMessage.getUser(), incomingMessage.getChannel(), incomingMessage.getDestinationChannel(), UserLevel.INTERNAL, MessagePriority.LOW);
         channel.receiveMessage(responseMessage);
     }
 }


### PR DESCRIPTION
Change event handling to use a Guava EventBus. Add Bot::eventBus,
and change message handlers for Beam and Twitch to use that instead
of Bot::invokeMessageHandlers.

Add a bunch of events which are not currently in use in preparation
for future event framework. Add AbstractServiceChannel and
ChannelState to prepare for monitoring whether a channel is live
and firing events based on that as well.