### PR TITLE
Fix problem with Bot::startBot

### DIFF
--- a/src/main/java/com/github/otbproject/otbproject/bot/Control.java
+++ b/src/main/java/com/github/otbproject/otbproject/bot/Control.java
@@ -154,7 +154,14 @@ public class Control {
             } catch (BotInitException e) {
                 App.logger.catching(e);
             }
+            handlePossibleFailedStartup();
         });
+    }
+
+    private static synchronized void handlePossibleFailedStartup() {
+        if (!bot.isConnected()) {
+            shutdown(true);
+        }
     }
 
     private static void init() {


### PR DESCRIPTION
Fix problem where, if Bot::startBot fails, Control will not
register that the bot is not running.