### PR TITLE
Initialize plugin data with futures

### DIFF
--- a/src/main/java/io/github/otbproject/otb/misc/SLambda.java
+++ b/src/main/java/io/github/otbproject/otb/misc/SLambda.java
@@ -2,6 +2,8 @@ package io.github.otbproject.otb.misc;
 
 import scala.Function0;
 import scala.Function1;
+import scala.Function2;
+import scala.Unit;
 
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -15,4 +17,8 @@ public final class SLambda {
     public static <T> Supplier<T> toSupplier(Function0<T> supplier) { return supplier::apply; }
 
     public static <T, R> Function<T, R> toFunction(Function1<T, R> func) { return func::apply; }
+
+    public static Thread.UncaughtExceptionHandler toUncaughtExceptionHandler(Function2<Thread, Throwable, Unit> func) {
+        return func::apply;
+    }
 }

--- a/src/main/java/io/github/otbproject/otb/plugin/content/DataRetrievalException.java
+++ b/src/main/java/io/github/otbproject/otb/plugin/content/DataRetrievalException.java
@@ -1,0 +1,11 @@
+package io.github.otbproject.otb.plugin.content;
+
+public class DataRetrievalException extends RuntimeException {
+    DataRetrievalException(ContentPlugin plugin) {
+        super("Plugin '" + plugin + "' failed to initialize data or did so too slowly, so it cannot be retrieved");
+    }
+
+    DataRetrievalException(String message, Throwable cause) { super(message, cause); }
+
+    DataRetrievalException(Throwable cause) { this("Exception during data initialization.", cause); }
+}

--- a/src/main/scala/io/github/otbproject/otb/misc/ThreadUtil.scala
+++ b/src/main/scala/io/github/otbproject/otb/misc/ThreadUtil.scala
@@ -1,0 +1,51 @@
+package io.github.otbproject.otb.misc
+
+import java.util.concurrent.{ExecutorService, Executors, ThreadFactory}
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder
+
+object ThreadUtil {
+  // TODO: implement uncaught exception handler
+  val UNCAUGHT_EXCEPTION_HANDLER = SLambda.toUncaughtExceptionHandler((t, e) => {
+    //      App.logger.error("Thread crashed: " + t.getName())
+    //      App.logger.catching(e)
+    //      Watcher.logException()
+  })
+
+  Thread.setDefaultUncaughtExceptionHandler(UNCAUGHT_EXCEPTION_HANDLER)
+
+  def newSingleThreadExecutor: ExecutorService = {
+    Executors.newSingleThreadExecutor(newThreadFactory)
+  }
+
+  def newThreadFactory: ThreadFactory = {
+    new ThreadFactoryBuilder()
+      .setUncaughtExceptionHandler(UNCAUGHT_EXCEPTION_HANDLER)
+      .build
+  }
+
+  def newSingleThreadExecutor(nameFormat: String): ExecutorService = {
+    Executors.newSingleThreadExecutor(newThreadFactory(nameFormat))
+  }
+
+  def newThreadFactory(nameFormat: String): ThreadFactory = {
+    new ThreadFactoryBuilder()
+      .setNameFormat(nameFormat)
+      .setUncaughtExceptionHandler(UNCAUGHT_EXCEPTION_HANDLER)
+      .build
+  }
+
+  def newCachedThreadPool: ExecutorService = {
+    Executors.newCachedThreadPool(newThreadFactory)
+  }
+
+  def newCachedThreadPool(nameFormat: String): ExecutorService = {
+    Executors.newCachedThreadPool(newThreadFactory(nameFormat))
+  }
+
+  def interruptIfInterruptedException(e: Exception) {
+    if (e.isInstanceOf[InterruptedException]) {
+      Thread.currentThread.interrupt()
+    }
+  }
+}

--- a/src/main/scala/io/github/otbproject/otb/plugin/content/PluginDataMap.scala
+++ b/src/main/scala/io/github/otbproject/otb/plugin/content/PluginDataMap.scala
@@ -1,32 +1,48 @@
 package io.github.otbproject.otb.plugin.content
 
+import java.util.concurrent.TimeUnit
+
 import scala.collection.mutable
+import scala.concurrent.duration.Duration
+import scala.concurrent.{Await, Future, TimeoutException}
 
-private[content] final class PluginDataMap private(map: Map[PluginDataTypeIdentifier[_], _ <: PluginData]) {
-  private val dataMap: Map[PluginDataTypeIdentifier[_], _ <: PluginData] = map
+private[content] final class PluginDataMap private(map: Map[PluginDataTypeIdentifier[_], Future[_ <: PluginData]]) {
+  private val dataMap: Map[PluginDataTypeIdentifier[_], Future[_ <: PluginData]] = map
 
+  @throws[DataRetrievalException]
   def get[T <: PluginData](identifier: PluginDataTypeIdentifier[T]): T = {
-    // Cast never fails because it is constrained that a type T object only gets
-    // inserted with a PluginDataTypeIdentifier[T] as its key
-    identifier.tClass.cast(dataMap.get(identifier))
+    try {
+      val future = dataMap.get(identifier).get
+      val data = Await.result(future, PluginDataMap.TIMEOUT_DURATION)
+      // Cast never fails because it is constrained that a type T object only gets
+      // inserted with a PluginDataTypeIdentifier[T] as its key
+      identifier.tClass.cast(data)
+    } catch {
+      case e: TimeoutException => throw new DataRetrievalException(identifier.plugin)
+      case e: NoSuchElementException => throw new DataRetrievalException("No data found for provided plugin", e)
+      case e: Throwable => throw new DataRetrievalException(e)
+    }
   }
 }
 
 private[content] object PluginDataMap {
+  val TIMEOUT_DURATION = Duration(4, TimeUnit.SECONDS)
+
   def newBuilder: Builder = new Builder
 
   final class Builder {
-    private val mutableMap = new mutable.HashMap[PluginDataTypeIdentifier[_], PluginData]()
+    private val map = new mutable.HashMap[PluginDataTypeIdentifier[_], Future[_ <: PluginData]]
 
+    // Exception should never be thrown
     @throws[IllegalArgumentException]
-    def put[T <: PluginData](identifier: PluginDataTypeIdentifier[T], data: T) = {
-      if (mutableMap contains identifier) {
+    def put[T <: PluginData](identifier: PluginDataTypeIdentifier[T], dataFuture: Future[T]) = {
+      if (map contains identifier) {
         throw new IllegalArgumentException("Plugin-Class mapping already present: " + identifier)
       }
-      mutableMap.put(identifier, data)
+      map.put(identifier, dataFuture)
     }
 
-    def build: PluginDataMap = new PluginDataMap(mutableMap.toMap)
+    def build: PluginDataMap = new PluginDataMap(map.toMap)
   }
 
 }


### PR DESCRIPTION
Instead of initializing plugin data synchronously, initialize it
asynchronously using Futures. PluginDataMap now stores Futures
instead of the data itself, and PluginDataMap.get retrieves the
value from the Future with a timeout.